### PR TITLE
Catalyst Adaptor implementation.

### DIFF
--- a/src/Vector/map_vector.hpp
+++ b/src/Vector/map_vector.hpp
@@ -2364,6 +2364,7 @@ namespace openfpm
 	template<typename T> using vector_gpu_lin = openfpm::vector<T,CudaMemory,memory_traits_lin>;
 	template<typename T> using vector_gpu_single = openfpm::vector<T,CudaMemory,memory_traits_inte,openfpm::grow_policy_identity>;
 	template<typename T> using vector_custd = vector<T, CudaMemory, memory_traits_inte, openfpm::grow_policy_double, STD_VECTOR>;
+	template<typename T> using vector_soa = openfpm::vector<T,HeapMemory,memory_traits_inte>;
 }
 
 #endif


### PR DESCRIPTION
Add `vector_soa` data structure required for Catalyst Adaptor.

Tied to [general Catalyst Adaptor PR](https://github.com/mosaic-group/openfpm_pdata/pull/10) in openfpm_pdata.