### PR TITLE
Use coalesced write

### DIFF
--- a/src/NN/CellList/cuda/CellList_gpu.hpp
+++ b/src/NN/CellList/cuda/CellList_gpu.hpp
@@ -451,25 +451,25 @@ public:
 			if (stop == (size_t)-1) stop = vPos.size();
 
 			if (opt & CL_GPU_REORDER_POSITION) {
-				CUDA_LAUNCH((reorderParticlesPos),
+				CUDA_LAUNCH((reorderParticlesPosCoalWrite),
 					vPos.getGPUIteratorTo(stop-start,64),
 					vPos.toKernel(),
 					vPosReorder.toKernel(),
-					unsortedToSortedIndex.toKernel(),
+					sortedToUnsortedIndex.toKernel(),
 					start
 				);
 			}
 
 			if (opt & CL_GPU_REORDER_PROPERTY && sizeof...(prp)) {
 				CUDA_LAUNCH(
-					(reorderParticlesPrp<
+					(reorderParticlesPrpCoalWrite<
 						decltype(vPrp.toKernel()),
 						decltype(unsortedToSortedIndex.toKernel()),
 						prp...>),
 					vPrp.getGPUIteratorTo(stop-start,64),
 					vPrp.toKernel(),
 					vPrpReorder.toKernel(),
-					unsortedToSortedIndex.toKernel(),
+					sortedToUnsortedIndex.toKernel(),
 					start
 				);
 			}
@@ -736,25 +736,25 @@ public:
 		if (stop == (size_t)-1) stop = vPosReordered.size();
 
 		if (opt & CL_GPU_RESTORE_POSITION) {
-			CUDA_LAUNCH((reorderParticlesPos),
+			CUDA_LAUNCH((reorderParticlesPosCoalWrite),
 				vPosReordered.getGPUIteratorTo(stop-start,64),
 				vPosReordered.toKernel(),
 				vPos.toKernel(),
-				sortedToUnsortedIndex.toKernel(),
+				unsortedToSortedIndex.toKernel(),
 				start
 			);
 		}
 
 		if (opt & CL_GPU_RESTORE_PROPERTY && sizeof...(prp)) {
 			CUDA_LAUNCH(
-				(reorderParticlesPrp<
+				(reorderParticlesPrpCoalWrite<
 					decltype(vPrpReordered.toKernel()),
 					decltype(sortedToUnsortedIndex.toKernel()),
 					prp...>),
 				vPrpReordered.getGPUIteratorTo(stop-start,64),
 				vPrpReordered.toKernel(),
 				vPrp.toKernel(),
-				sortedToUnsortedIndex.toKernel(),
+				unsortedToSortedIndex.toKernel(),
 				start
 			);
 		}
@@ -1206,25 +1206,26 @@ public:
 			if (stop == (size_t)-1) stop = vPos.size();
 
 			if (opt & CL_GPU_REORDER_POSITION) {
-				CUDA_LAUNCH((reorderParticlesPos),
+				CUDA_LAUNCH((reorderParticlesPosCoalWrite),
 					vPos.getGPUIteratorTo(stop-start,64),
 					vPos.toKernel(),
 					vPosReorder.toKernel(),
-					unsortedToSortedIndex.toKernel(),
+					sortedToUnsortedIndex.toKernel(),
 					start
 				);
+				
 			}
 
 			if (opt & CL_GPU_REORDER_PROPERTY && sizeof...(prp)) {
 				CUDA_LAUNCH(
-					(reorderParticlesPrp<
+					(reorderParticlesPrpCoalWrite<
 						decltype(vPrp.toKernel()),
 						decltype(unsortedToSortedIndex.toKernel()),
 						prp...>),
 					vPrp.getGPUIteratorTo(stop-start,64),
 					vPrp.toKernel(),
 					vPrpReorder.toKernel(),
-					unsortedToSortedIndex.toKernel(),
+					sortedToUnsortedIndex.toKernel(),
 					start
 				);
 			}
@@ -1471,25 +1472,25 @@ public:
 		if (stop == (size_t)-1) stop = vPosReordered.size();
 
 		if (opt & CL_GPU_RESTORE_POSITION) {
-			CUDA_LAUNCH((reorderParticlesPos),
+			CUDA_LAUNCH((reorderParticlesPosCoalWrite),
 				vPosReordered.getGPUIteratorTo(stop-start,64),
 				vPosReordered.toKernel(),
 				vPos.toKernel(),
-				sortedToUnsortedIndex.toKernel(),
+				unsortedToSortedIndex.toKernel(),
 				start
 			);
 		}
 
 		if (opt & CL_GPU_RESTORE_PROPERTY && sizeof...(prp)) {
 			CUDA_LAUNCH(
-				(reorderParticlesPrp<
+				(reorderParticlesPrpCoalWrite<
 					decltype(vPrpReordered.toKernel()),
 					decltype(sortedToUnsortedIndex.toKernel()),
 					prp...>),
 				vPrpReordered.getGPUIteratorTo(stop-start,64),
 				vPrpReordered.toKernel(),
 				vPrp.toKernel(),
-				sortedToUnsortedIndex.toKernel(),
+				unsortedToSortedIndex.toKernel(),
 				start
 			);
 		}

--- a/src/NN/CellList/cuda/Cuda_cell_list_util_func.hpp
+++ b/src/NN/CellList/cuda/Cuda_cell_list_util_func.hpp
@@ -415,6 +415,37 @@ __global__ void reorderParticlesPrp(
 	vectorOut.template set<prp ...>(keyOut,vectorIn,keyIn);
 }
 
+template <typename vector_type, typename vector_map_type>
+__global__ void reorderParticlesPosCoalWrite(
+	const vector_type vectorIn,
+	vector_type vectorOut,
+	const vector_map_type indexMap,
+	size_t start = 0)
+{
+	int keyWrite = start + threadIdx.x + blockIdx.x * blockDim.x;
+	if (keyWrite >= indexMap.size())	{return;}
+
+	unsigned int keyRead = indexMap.template get<0>(keyWrite);
+
+	vectorOut.set(keyWrite,vectorIn,keyRead);
+}
+
+template <typename vector_type, typename vector_map_type, unsigned int ... prp>
+__global__ void reorderParticlesPrpCoalWrite(
+	const vector_type vectorIn,
+	vector_type vectorOut,
+	vector_map_type indexMap,
+	size_t start = 0)
+{
+	int keyWrite = start + threadIdx.x + blockIdx.x * blockDim.x;
+	if (keyWrite >= indexMap.size())	{return;}
+
+	unsigned int keyRead = indexMap.template get<0>(keyWrite);
+
+	vectorOut.template set<prp ...>(keyWrite,vectorIn,keyRead);
+}
+
+
 template<typename vector_sort_index, typename vector_out_type>
 __global__ void mark_domain_particles(
 	vector_sort_index sortedToUnsortedIndex,


### PR DESCRIPTION
Reworked memory access for `reorderParticles*`-functions to avoid uncoalesced writes. Uncoalesced writes are more expensive than uncoalesced reads on GPUs; the new access pattern uses coalesced writes. (Gather memory write instead of scatter memory write)